### PR TITLE
Support multiple training backends

### DIFF
--- a/python/kubeflow/trainer/__init__.py
+++ b/python/kubeflow/trainer/__init__.py
@@ -40,3 +40,9 @@ from kubeflow.trainer.types.types import (
     TrainerType,
     TorchTuneConfig,
 )
+from kubeflow.trainer.backends import (
+    DockerBackend,
+    PodmanBackend,
+    SubprocessBackend,
+    TrainingBackend,
+)

--- a/python/kubeflow/trainer/__init__.py
+++ b/python/kubeflow/trainer/__init__.py
@@ -35,7 +35,7 @@ from kubeflow.trainer.types.types import (
     Initializer,
     TorchTuneInstructDataset,
     Loss,
-    Runtime,
+    TrainingRuntime,
     Trainer,
     TrainerType,
     TorchTuneConfig,

--- a/python/kubeflow/trainer/api/trainer_client.py
+++ b/python/kubeflow/trainer/api/trainer_client.py
@@ -99,16 +99,16 @@ class TrainerClient:
         if backend_type == "docker":
             if "image" not in config:
                 raise ValueError("Docker backend requires 'image' in backend_config")
-            return DockerBackend(config["image"], config.get("args"))
+            return DockerBackend(config["image"], config.get("run_kwargs"))
         if backend_type == "podman":
             if "image" not in config:
                 raise ValueError("Podman backend requires 'image' in backend_config")
-            return PodmanBackend(config["image"], config.get("args"))
+            return PodmanBackend(config["image"], config.get("run_kwargs"))
         if backend_type == "subprocess":
             return SubprocessBackend(config.get("env"))
         raise ValueError(f"Unsupported backend type: {backend_type}")
 
-    def list_runtimes(self) -> List[types.Runtime]:
+    def list_runtimes(self) -> List[types.TrainingRuntime]:
         """List of the available Runtimes.
 
         Returns:
@@ -156,7 +156,7 @@ class TrainerClient:
 
         return result
 
-    def get_runtime(self, name: str) -> types.Runtime:
+    def get_runtime(self, name: str) -> types.TrainingRuntime:
         """Get the the Runtime object"""
 
         if self.backend_type != "kubernetes":
@@ -192,7 +192,7 @@ class TrainerClient:
 
     def train(
         self,
-        runtime: types.Runtime = types.DEFAULT_RUNTIME,
+        runtime: types.TrainingRuntime = types.DEFAULT_RUNTIME,
         initializer: Optional[types.Initializer] = None,
         trainer: Optional[types.CustomTrainer] = None,
     ) -> str:
@@ -203,7 +203,7 @@ class TrainerClient:
             the entire model training process, e.g. `CustomTrainer`.
 
         Args:
-            runtime (`types.Runtime`): Reference to one of existing Runtimes.
+            runtime (`types.TrainingRuntime`): Reference to one of existing TrainingRuntimes.
             initializer (`Optional[types.Initializer]`):
                 Configuration for the dataset and model initializers.
             trainer (`Optional[types.CustomTrainer]`):
@@ -317,7 +317,7 @@ class TrainerClient:
         return train_job_name
 
     def list_jobs(
-        self, runtime: Optional[types.Runtime] = None
+        self, runtime: Optional[types.TrainingRuntime] = None
     ) -> List[types.TrainJob]:
         """List of all TrainJobs.
 
@@ -551,7 +551,7 @@ class TrainerClient:
     def __get_runtime_from_crd(
         self,
         runtime_crd: models.TrainerV1alpha1ClusterTrainingRuntime,
-    ) -> types.Runtime:
+    ) -> types.TrainingRuntime:
 
         if not (
             runtime_crd.metadata
@@ -563,7 +563,7 @@ class TrainerClient:
         ):
             raise Exception(f"ClusterTrainingRuntime CRD is invalid: {runtime_crd}")
 
-        return types.Runtime(
+        return types.TrainingRuntime(
             name=runtime_crd.metadata.name,
             trainer=utils.get_runtime_trainer(
                 runtime_crd.spec.template.spec.replicated_jobs,

--- a/python/kubeflow/trainer/api/trainer_client.py
+++ b/python/kubeflow/trainer/api/trainer_client.py
@@ -243,7 +243,7 @@ class TrainerClient:
 
             if not self.backend:
                 raise RuntimeError("Backend is not configured")
-            self.backend.run(command, args)
+            self.backend.run(command, args, train_job_name, runtime.name)
             return train_job_name
 
         # Build the Trainer.
@@ -331,9 +331,12 @@ class TrainerClient:
         """
 
         if self.backend_type != "kubernetes":
-            raise NotImplementedError(
-                "list_jobs is only available for the kubernetes backend"
-            )
+            if not self.backend:
+                raise RuntimeError("Backend is not configured")
+            jobs = self.backend.list_jobs()
+            if runtime is not None:
+                jobs = [j for j in jobs if j.runtime.name == runtime.name]
+            return jobs
 
         result = []
         try:
@@ -379,9 +382,9 @@ class TrainerClient:
         """Get the TrainJob object"""
 
         if self.backend_type != "kubernetes":
-            raise NotImplementedError(
-                "get_job is only available for the kubernetes backend"
-            )
+            if not self.backend:
+                raise RuntimeError("Backend is not configured")
+            return self.backend.get_job(name)
 
         try:
             thread = self.custom_api.get_namespaced_custom_object(
@@ -418,9 +421,9 @@ class TrainerClient:
         """Get the logs from TrainJob"""
 
         if self.backend_type != "kubernetes":
-            raise NotImplementedError(
-                "get_job_logs is only available for the kubernetes backend"
-            )
+            if not self.backend:
+                raise RuntimeError("Backend is not configured")
+            return self.backend.get_job_logs(name)
 
         # Get the TrainJob Pod name.
         pod_name = None

--- a/python/kubeflow/trainer/backends/__init__.py
+++ b/python/kubeflow/trainer/backends/__init__.py
@@ -1,0 +1,11 @@
+from .base import TrainingBackend
+from .docker_backend import DockerBackend
+from .podman_backend import PodmanBackend
+from .subprocess_backend import SubprocessBackend
+
+__all__ = [
+    "TrainingBackend",
+    "DockerBackend",
+    "PodmanBackend",
+    "SubprocessBackend",
+]

--- a/python/kubeflow/trainer/backends/base.py
+++ b/python/kubeflow/trainer/backends/base.py
@@ -1,0 +1,22 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional
+
+
+class TrainingBackend(ABC):
+    """Abstract base class for trainer execution backends."""
+
+    def __init__(self, image: Optional[str] = None):
+        self.image = image
+
+    @abstractmethod
+    def run(self, command: List[str], args: List[str]) -> int:
+        """Run the provided command.
+
+        Args:
+            command: The container command or entrypoint.
+            args: Arguments for the command.
+
+        Returns:
+            Exit code from the execution process.
+        """
+        raise NotImplementedError

--- a/python/kubeflow/trainer/backends/base.py
+++ b/python/kubeflow/trainer/backends/base.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import Dict, List, Optional
+
+from kubeflow.trainer.types import types
 
 
 class TrainingBackend(ABC):
@@ -9,7 +11,13 @@ class TrainingBackend(ABC):
         self.image = image
 
     @abstractmethod
-    def run(self, command: List[str], args: List[str]) -> int:
+    def run(
+        self,
+        command: List[str],
+        args: List[str],
+        job_name: str,
+        runtime_name: str,
+    ) -> int:
         """Run the provided command.
 
         Args:
@@ -19,4 +27,13 @@ class TrainingBackend(ABC):
         Returns:
             Exit code from the execution process.
         """
+        raise NotImplementedError
+
+    def list_jobs(self) -> List["types.TrainJob"]:
+        raise NotImplementedError
+
+    def get_job(self, name: str) -> "types.TrainJob":
+        raise NotImplementedError
+
+    def get_job_logs(self, name: str) -> Dict[str, str]:
         raise NotImplementedError

--- a/python/kubeflow/trainer/backends/docker_backend.py
+++ b/python/kubeflow/trainer/backends/docker_backend.py
@@ -1,27 +1,25 @@
-import subprocess
-from typing import List, Optional
+from typing import Dict, List, Optional
+
+import docker
 
 from .base import TrainingBackend
 
 
 class DockerBackend(TrainingBackend):
-    """Backend using docker CLI to run training containers."""
+    """Backend using the Docker SDK to run training containers."""
 
-    def __init__(self, image: str, additional_args: Optional[List[str]] = None):
+    def __init__(self, image: str, run_kwargs: Optional[Dict] = None):
         super().__init__(image=image)
-        self.additional_args = additional_args or []
+        self.client = docker.from_env()
+        self.run_kwargs = run_kwargs or {}
 
     def run(self, command: List[str], args: List[str]) -> int:
-        docker_cmd = (
-            [
-                "docker",
-                "run",
-                "--rm",
-            ]
-            + self.additional_args
-            + [self.image]
-            + command
-            + args
+        container = self.client.containers.create(
+            self.image,
+            command + args,
+            **self.run_kwargs,
         )
-        proc = subprocess.run(docker_cmd, check=False)
-        return proc.returncode
+        container.start()
+        result = container.wait()
+        container.remove()
+        return result.get("StatusCode", 1)

--- a/python/kubeflow/trainer/backends/docker_backend.py
+++ b/python/kubeflow/trainer/backends/docker_backend.py
@@ -1,0 +1,27 @@
+import subprocess
+from typing import List, Optional
+
+from .base import TrainingBackend
+
+
+class DockerBackend(TrainingBackend):
+    """Backend using docker CLI to run training containers."""
+
+    def __init__(self, image: str, additional_args: Optional[List[str]] = None):
+        super().__init__(image=image)
+        self.additional_args = additional_args or []
+
+    def run(self, command: List[str], args: List[str]) -> int:
+        docker_cmd = (
+            [
+                "docker",
+                "run",
+                "--rm",
+            ]
+            + self.additional_args
+            + [self.image]
+            + command
+            + args
+        )
+        proc = subprocess.run(docker_cmd, check=False)
+        return proc.returncode

--- a/python/kubeflow/trainer/backends/docker_backend.py
+++ b/python/kubeflow/trainer/backends/docker_backend.py
@@ -1,7 +1,10 @@
+from datetime import datetime
 from typing import Dict, List, Optional
 
 import docker
 
+from ..constants import constants
+from ..types import types
 from .base import TrainingBackend
 
 
@@ -13,13 +16,66 @@ class DockerBackend(TrainingBackend):
         self.client = docker.from_env()
         self.run_kwargs = run_kwargs or {}
 
-    def run(self, command: List[str], args: List[str]) -> int:
+    def run(
+        self,
+        command: List[str],
+        args: List[str],
+        job_name: str,
+        runtime_name: str,
+    ) -> int:
+        labels = {
+            constants.LOCAL_TRAINJOB_LABEL: job_name,
+            constants.LOCAL_RUNTIME_LABEL: runtime_name,
+        }
         container = self.client.containers.create(
             self.image,
             command + args,
+            labels=labels,
             **self.run_kwargs,
         )
         container.start()
         result = container.wait()
-        container.remove()
         return result.get("StatusCode", 1)
+
+    def _to_trainjob(self, container) -> types.TrainJob:
+        created = datetime.fromisoformat(
+            container.attrs["Created"].replace("Z", "+00:00")
+        )
+        runtime_name = container.labels.get(constants.LOCAL_RUNTIME_LABEL, "local")
+        runtime = types.TrainingRuntime(
+            name=runtime_name, trainer=types.DEFAULT_TRAINER
+        )
+        status = container.status.capitalize()
+        step = types.Step(name=constants.NODE, status=status, pod_name=container.name)
+        return types.TrainJob(
+            name=container.labels.get(constants.LOCAL_TRAINJOB_LABEL, container.name),
+            creation_timestamp=created,
+            runtime=runtime,
+            steps=[step],
+            status=status,
+        )
+
+    def list_jobs(self) -> List[types.TrainJob]:
+        containers = self.client.containers.list(
+            all=True, filters={"label": constants.LOCAL_TRAINJOB_LABEL}
+        )
+        return [self._to_trainjob(c) for c in containers]
+
+    def get_job(self, name: str) -> types.TrainJob:
+        containers = self.client.containers.list(
+            all=True,
+            filters={"label": f"{constants.LOCAL_TRAINJOB_LABEL}={name}"},
+        )
+        if not containers:
+            raise ValueError(f"Job {name} not found")
+        return self._to_trainjob(containers[0])
+
+    def get_job_logs(self, name: str) -> Dict[str, str]:
+        containers = self.client.containers.list(
+            all=True,
+            filters={"label": f"{constants.LOCAL_TRAINJOB_LABEL}={name}"},
+        )
+        if not containers:
+            return {}
+        logs = containers[0].logs().decode()
+        return {f"{constants.NODE}-0": logs}

--- a/python/kubeflow/trainer/backends/podman_backend.py
+++ b/python/kubeflow/trainer/backends/podman_backend.py
@@ -1,7 +1,10 @@
+from datetime import datetime
 from typing import Dict, List, Optional
 
 from podman import PodmanClient
 
+from ..constants import constants
+from ..types import types
 from .base import TrainingBackend
 
 
@@ -13,13 +16,66 @@ class PodmanBackend(TrainingBackend):
         self.client = PodmanClient()
         self.run_kwargs = run_kwargs or {}
 
-    def run(self, command: List[str], args: List[str]) -> int:
+    def run(
+        self,
+        command: List[str],
+        args: List[str],
+        job_name: str,
+        runtime_name: str,
+    ) -> int:
+        labels = {
+            constants.LOCAL_TRAINJOB_LABEL: job_name,
+            constants.LOCAL_RUNTIME_LABEL: runtime_name,
+        }
         container = self.client.containers.create(
             self.image,
             command + args,
+            labels=labels,
             **self.run_kwargs,
         )
         container.start()
         result = container.wait()
-        container.remove()
         return result.get("StatusCode", 1)
+
+    def _to_trainjob(self, container) -> types.TrainJob:
+        created = datetime.fromisoformat(
+            container.attrs["Created"].replace("Z", "+00:00")
+        )
+        runtime_name = container.labels.get(constants.LOCAL_RUNTIME_LABEL, "local")
+        runtime = types.TrainingRuntime(
+            name=runtime_name, trainer=types.DEFAULT_TRAINER
+        )
+        status = container.status.capitalize()
+        step = types.Step(name=constants.NODE, status=status, pod_name=container.name)
+        return types.TrainJob(
+            name=container.labels.get(constants.LOCAL_TRAINJOB_LABEL, container.name),
+            creation_timestamp=created,
+            runtime=runtime,
+            steps=[step],
+            status=status,
+        )
+
+    def list_jobs(self) -> List[types.TrainJob]:
+        containers = self.client.containers.list(
+            all=True, filters={"label": constants.LOCAL_TRAINJOB_LABEL}
+        )
+        return [self._to_trainjob(c) for c in containers]
+
+    def get_job(self, name: str) -> types.TrainJob:
+        containers = self.client.containers.list(
+            all=True,
+            filters={"label": f"{constants.LOCAL_TRAINJOB_LABEL}={name}"},
+        )
+        if not containers:
+            raise ValueError(f"Job {name} not found")
+        return self._to_trainjob(containers[0])
+
+    def get_job_logs(self, name: str) -> Dict[str, str]:
+        containers = self.client.containers.list(
+            all=True,
+            filters={"label": f"{constants.LOCAL_TRAINJOB_LABEL}={name}"},
+        )
+        if not containers:
+            return {}
+        logs = containers[0].logs().decode()
+        return {f"{constants.NODE}-0": logs}

--- a/python/kubeflow/trainer/backends/podman_backend.py
+++ b/python/kubeflow/trainer/backends/podman_backend.py
@@ -1,0 +1,27 @@
+import subprocess
+from typing import List, Optional
+
+from .base import TrainingBackend
+
+
+class PodmanBackend(TrainingBackend):
+    """Backend using podman CLI to run training containers."""
+
+    def __init__(self, image: str, additional_args: Optional[List[str]] = None):
+        super().__init__(image=image)
+        self.additional_args = additional_args or []
+
+    def run(self, command: List[str], args: List[str]) -> int:
+        podman_cmd = (
+            [
+                "podman",
+                "run",
+                "--rm",
+            ]
+            + self.additional_args
+            + [self.image]
+            + command
+            + args
+        )
+        proc = subprocess.run(podman_cmd, check=False)
+        return proc.returncode

--- a/python/kubeflow/trainer/backends/subprocess_backend.py
+++ b/python/kubeflow/trainer/backends/subprocess_backend.py
@@ -1,0 +1,16 @@
+import subprocess
+from typing import List, Optional
+
+from .base import TrainingBackend
+
+
+class SubprocessBackend(TrainingBackend):
+    """Backend that runs commands directly using subprocess."""
+
+    def __init__(self, env: Optional[dict] = None):
+        super().__init__(image=None)
+        self.env = env
+
+    def run(self, command: List[str], args: List[str]) -> int:
+        proc = subprocess.run(command + args, env=self.env, check=False)
+        return proc.returncode

--- a/python/kubeflow/trainer/backends/subprocess_backend.py
+++ b/python/kubeflow/trainer/backends/subprocess_backend.py
@@ -1,6 +1,9 @@
 import subprocess
-from typing import List, Optional
+from datetime import datetime
+from typing import Dict, List, Optional
 
+from ..constants import constants
+from ..types import types
 from .base import TrainingBackend
 
 
@@ -10,7 +13,58 @@ class SubprocessBackend(TrainingBackend):
     def __init__(self, env: Optional[dict] = None):
         super().__init__(image=None)
         self.env = env
+        self._jobs: Dict[str, subprocess.CompletedProcess] = {}
+        self._start_times: Dict[str, datetime] = {}
+        self._runtime_names: Dict[str, str] = {}
 
-    def run(self, command: List[str], args: List[str]) -> int:
-        proc = subprocess.run(command + args, env=self.env, check=False)
+    def run(
+        self,
+        command: List[str],
+        args: List[str],
+        job_name: str,
+        runtime_name: str,
+    ) -> int:
+        proc = subprocess.run(
+            command + args,
+            env=self.env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self._jobs[job_name] = proc
+        self._start_times[job_name] = datetime.utcnow()
+        self._runtime_names[job_name] = runtime_name
         return proc.returncode
+
+    def _to_trainjob(
+        self, name: str, proc: subprocess.CompletedProcess
+    ) -> types.TrainJob:
+        created = self._start_times.get(name, datetime.utcnow())
+        runtime_name = self._runtime_names.get(name, "local")
+        runtime = types.TrainingRuntime(
+            name=runtime_name, trainer=types.DEFAULT_TRAINER
+        )
+        status = "Succeeded" if proc.returncode == 0 else "Failed"
+        step = types.Step(name=constants.NODE, status=status, pod_name=name)
+        return types.TrainJob(
+            name=name,
+            creation_timestamp=created,
+            runtime=runtime,
+            steps=[step],
+            status=status,
+        )
+
+    def list_jobs(self) -> List[types.TrainJob]:
+        return [self._to_trainjob(n, p) for n, p in self._jobs.items()]
+
+    def get_job(self, name: str) -> types.TrainJob:
+        if name not in self._jobs:
+            raise ValueError(f"Job {name} not found")
+        return self._to_trainjob(name, self._jobs[name])
+
+    def get_job_logs(self, name: str) -> Dict[str, str]:
+        if name not in self._jobs:
+            return {}
+        proc = self._jobs[name]
+        logs = (proc.stdout or "") + (proc.stderr or "")
+        return {f"{constants.NODE}-0": logs}

--- a/python/kubeflow/trainer/constants/constants.py
+++ b/python/kubeflow/trainer/constants/constants.py
@@ -94,6 +94,10 @@ JOBSET_RJOB_NAME_LABEL = "jobset.sigs.k8s.io/replicatedjob-name"
 # The label key to identify the Job completion index of the Pod.
 JOB_INDEX_LABEL = "batch.kubernetes.io/job-completion-index"
 
+# Label keys used by local training backends (Docker, Podman, subprocesses).
+LOCAL_TRAINJOB_LABEL = "trainer.kubeflow.org/trainjob-name"
+LOCAL_RUNTIME_LABEL = "trainer.kubeflow.org/runtime-name"
+
 # The Pod pending phase indicates that Pod has been accepted by the Kubernetes cluster,
 # but one or more of the containers has not been made ready to run.
 POD_PENDING = "Pending"

--- a/python/kubeflow/trainer/types/types.py
+++ b/python/kubeflow/trainer/types/types.py
@@ -173,7 +173,7 @@ class Trainer:
 
 # Representation for the Training Runtime.
 @dataclass
-class Runtime:
+class TrainingRuntime:
     name: str
     trainer: Trainer
     pretrained_model: Optional[str] = None
@@ -195,7 +195,7 @@ class Step:
 class TrainJob:
     name: str
     creation_timestamp: datetime
-    runtime: Runtime
+    runtime: TrainingRuntime
     steps: List[Step]
     status: Optional[str] = constants.UNKNOWN
 
@@ -278,7 +278,7 @@ DEFAULT_TRAINER = Trainer(
 )
 
 # The default runtime configuration for the train() API
-DEFAULT_RUNTIME = Runtime(
+DEFAULT_RUNTIME = TrainingRuntime(
     name="torch-distributed",
     trainer=DEFAULT_TRAINER,
 )

--- a/python/kubeflow/trainer/utils/utils.py
+++ b/python/kubeflow/trainer/utils/utils.py
@@ -21,9 +21,9 @@ import threading
 from typing import Any, Callable, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
-from kubeflow_trainer_api import models
 from kubeflow.trainer.constants import constants
 from kubeflow.trainer.types import types
+from kubeflow_trainer_api import models
 from kubernetes import config
 
 
@@ -183,7 +183,7 @@ def get_trainjob_node_step(
     pod_name: str,
     pod_spec: models.IoK8sApiCoreV1PodSpec,
     pod_status: Optional[models.IoK8sApiCoreV1PodStatus],
-    trainjob_runtime: types.Runtime,
+    trainjob_runtime: types.TrainingRuntime,
     replicated_job_name: str,
     job_index: int,
 ) -> types.Step:
@@ -247,7 +247,7 @@ def get_resources_per_node(
 
 
 def get_entrypoint_using_train_func(
-    runtime: types.Runtime,
+    runtime: types.TrainingRuntime,
     train_func: Callable,
     train_func_parameters: Optional[Dict[str, Any]],
     pip_index_url: str,
@@ -386,7 +386,7 @@ def get_args_using_torchtune_config(
 
 def get_trainer_crd_from_custom_trainer(
     trainer: types.CustomTrainer,
-    runtime: types.Runtime,
+    runtime: types.TrainingRuntime,
 ) -> models.TrainerV1alpha1Trainer:
     """
     Get the Trainer CRD from the custom trainer.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -32,7 +32,9 @@ classifiers = [
 dependencies = [
   "kubernetes>=27.2.0",
   "pydantic>=2.10.0",
-  "kubeflow_trainer_api@git+https://github.com/kubeflow/trainer.git@master#subdirectory=api/python_api"
+"kubeflow_trainer_api@git+https://github.com/kubeflow/trainer.git@master#subdirectory=api/python_api",
+"docker>=7.0.0",
+"podman>=4.8.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- add training backend infrastructure
- implement docker, podman and subprocess backends
- expose backends in kubeflow.trainer package
- extend TrainerClient to select and use different backends

## Testing
- `pre-commit run --files python/kubeflow/trainer/api/trainer_client.py python/kubeflow/trainer/__init__.py python/kubeflow/trainer/backends/base.py python/kubeflow/trainer/backends/docker_backend.py python/kubeflow/trainer/backends/podman_backend.py python/kubeflow/trainer/backends/subprocess_backend.py`

------
https://chatgpt.com/codex/tasks/task_e_684c47a6028c832d8e22b124d94b26ff